### PR TITLE
Set timeout on deploy SC to 60s (20s is too low)

### DIFF
--- a/packages/sc-deployer/src/index.ts
+++ b/packages/sc-deployer/src/index.ts
@@ -340,7 +340,7 @@ async function deploySC(
   const { isError, eventPoller, events }: IEventPollerResult =
     await utils.time.withTimeoutRejection<IEventPollerResult>(
       pollAsyncEvents(client, opId),
-      20000,
+      60000,
     );
 
   // stop polling


### PR DESCRIPTION
In Massa, finality is typically of the order of 40 seconds. The current timeout on SC deployment is too short (20s), especially in case of congestion or high miss rates. This PR increases the timeout to prevent spurious timeouts.